### PR TITLE
Document gem dependencies in a Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+ruby '1.9.3', engine: 'jruby', engine_version: '1.7.16'
+
+gem 'minitest'
+gem 'pacer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    httpclient (2.6.0.1)
+    lock_jar (0.12.6)
+      naether (~> 0.14.3)
+      thor (>= 0.18.1)
+    minitest (5.8.0)
+    naether (0.14.3-java)
+      httpclient
+    pacer (2.0.20-java)
+      lock_jar (~> 0.12.0)
+    thor (0.19.1)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  minitest
+  pacer
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Uses a `Gemfile` to: 
- [x] Explicitly declare the required/supported JRuby version.
- [x] List dependencies in one spot. 
  Instead of installing `pacer` and `minitest` as independednt gems, install Bundler (`gem install bundler`) and then `bundle install` to install all dependencies.

Next: add [guard](https://github.com/guard/guard) to the list to run the exercise tests more interactively.
